### PR TITLE
Passing array on 'body' POST request is deprecated

### DIFF
--- a/app/Auth/Proxy.php
+++ b/app/Auth/Proxy.php
@@ -34,7 +34,7 @@ class Proxy {
 
             $client = new Client();
             $guzzleResponse = $client->post(sprintf('%s/oauth/access-token', $config->get('app.url')), [
-                'body' => $data
+                'form_params' => $data
             ]);
         } catch(\GuzzleHttp\Exception\BadResponseException $e) {
             $guzzleResponse = $e->getResponse();


### PR DESCRIPTION
based on this:
https://github.com/guzzle/guzzle/blob/master/src/Client.php#L117
