### PR TITLE
Guzzle expects User Model in \App\User not \App\Auth\User

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -1,6 +1,6 @@
 <?php 
 
-namespace App\Auth;
+namespace App;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
Guzzle was generating an exception based on looking for \App\User and not finding it. This moves the User model into the expected location.
